### PR TITLE
fix flask_dance import issue

### DIFF
--- a/flask_turbo_boost/project/application/models/flask_dance_oauth.py
+++ b/flask_turbo_boost/project/application/models/flask_dance_oauth.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from flask_dance.consumer.backend.sqla import OAuthConsumerMixin
+from flask_dance.consumer.storage.sqla import OAuthConsumerMixin
 from ._base import db
 
 

--- a/flask_turbo_boost/project/application/utils/flask_dance.py
+++ b/flask_turbo_boost/project/application/utils/flask_dance.py
@@ -1,7 +1,7 @@
 from flask import flash
 from application.models import db, OAuth, User
 from flask_dance.contrib.facebook import make_facebook_blueprint, facebook
-from flask_dance.consumer.backend.sqla import SQLAlchemyBackend
+from flask_dance.consumer.storage.sqla import SQLAlchemyBackend
 from flask_dance.consumer import oauth_authorized
 from flask_security import login_user, current_user
 

--- a/flask_turbo_boost/project/application/utils/flask_dance.py
+++ b/flask_turbo_boost/project/application/utils/flask_dance.py
@@ -1,7 +1,7 @@
 from flask import flash
 from application.models import db, OAuth, User
 from flask_dance.contrib.facebook import make_facebook_blueprint, facebook
-from flask_dance.consumer.storage.sqla import SQLAlchemyBackend
+from flask_dance.consumer.storage.sqla import SQLAlchemyStorage
 from flask_dance.consumer import oauth_authorized
 from flask_security import login_user, current_user
 
@@ -11,7 +11,7 @@ def init_flask_dance(app):
         client_id=app.config.get("FACEBOOK_CLIENT_ID"),
         client_secret=app.config.get("FACEBOOK_CLIENT_SECRET"),
         scope='email',
-        backend=SQLAlchemyBackend(OAuth, session=db.session)
+        backend=SQLAlchemyStorage(OAuth, session=db.session)
     )
 
     @oauth_authorized.connect_via(fb_blueprint)


### PR DESCRIPTION
This PR fixes an issue caused by the `flask-dance` library which renamed 'backend' to 'storage' in [this commit](https://github.com/singingwolfboy/flask-dance/pull/225/commits/0565aa23f79782c8352fa7cadcedd76283875fed]). Projects not using this fix thow a `ModuleNotFoundError: No module named 'flask_dance.consumer.backend'` error when running Flask commands like `flask run` and `flask db upgrade`.
